### PR TITLE
remove / in urlconf for view router (fixes #19)

### DIFF
--- a/{{cookiecutter.github_repo}}/{{cookiecutter.python_package_namespace}}/{{cookiecutter.python_subpackage}}/urls.py
+++ b/{{cookiecutter.github_repo}}/{{cookiecutter.python_package_namespace}}/{{cookiecutter.python_subpackage}}/urls.py
@@ -5,5 +5,5 @@ from rest_framework.routers import DefaultRouter
 router = DefaultRouter()
 
 urlpatterns = [
-    url(r'^/', include(router.urls)),
+    url(r'^', include(router.urls)),
 ]


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Included your name and github handle in the contributors.md - Contributors section
- [ ] Major/Breaking Changes are listed in Changelog

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix.

* **What is the current behavior?** (You can also link to an open issue here)

View endpoint URLs contain double `//`s. Fixes #19 

* **What is the new behavior (if this is a feature change)?**

Cookiecutter template generates view endpoints correctly.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Possibly, if frontend was consuming API. I don't think we have published this template very widely yet or any frontend are using endpoints generated from the cookiecutter template yet.

* **Other information**:
